### PR TITLE
Xaero's minimap rendering

### DIFF
--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/OreVeinRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/OreVeinRenderStep.java
@@ -13,6 +13,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +31,7 @@ public class OreVeinRenderStep implements InteractableRenderStep {
     }
 
     @Override
-    public void draw(GuiScreen gui, double cameraX, double cameraZ, double scale) {
+    public void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale) {
         final double iconSizeHalf = iconSize / 2;
         final double scaleForGui = Math.max(1, scale);
         iconX = (oreVeinLocation.getBlockX() - 0.5 - cameraX) * scaleForGui - iconSizeHalf;
@@ -50,7 +51,7 @@ public class OreVeinRenderStep implements InteractableRenderStep {
             }
         }
 
-        if (scale >= Utils.journeyMapScaleToLinear(Config.minZoomLevelForOreLabel) && !oreVeinLocation.isDepleted()) {
+        if (gui != null && scale >= Utils.journeyMapScaleToLinear(Config.minZoomLevelForOreLabel) && !oreVeinLocation.isDepleted()) {
             final int fontColor = oreVeinLocation.drawSearchHighlight() ? 0xFFFFFFFF : 0xFF7F7F7F;
             String text = I18n.format(oreVeinLocation.getName());
             DrawUtils.drawSimpleLabel(gui, text, 0, -iconSizeHalf - gui.mc.fontRenderer.FONT_HEIGHT - 5, fontColor, 0xB4000000, true);

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/RenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/RenderStep.java
@@ -2,6 +2,8 @@ package com.sinthoras.visualprospecting.integration.xaeroworldmap.rendersteps;
 
 import net.minecraft.client.gui.GuiScreen;
 
+import javax.annotation.Nullable;
+
 public interface RenderStep {
-    void draw(GuiScreen gui, double cameraX, double cameraZ, double scale);
+    void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale);
 }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/ThaumcraftNodeRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/ThaumcraftNodeRenderStep.java
@@ -11,6 +11,8 @@ import org.lwjgl.opengl.GL11;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.client.lib.UtilsFX;
 
+import javax.annotation.Nullable;
+
 public class ThaumcraftNodeRenderStep implements InteractableRenderStep {
 
     private static final ResourceLocation markedTextureLocation = new ResourceLocation(Tags.MODID, "textures/node_marked.png");
@@ -27,7 +29,7 @@ public class ThaumcraftNodeRenderStep implements InteractableRenderStep {
     }
 
     @Override
-    public void draw(GuiScreen gui, double cameraX, double cameraZ, double scale) {
+    public void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale) {
         final double borderSize = 44;
         final double borderSizeHalf = borderSize / 2;
         final double scaleForGui = Math.max(0.5, scale);

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidChunkRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidChunkRenderStep.java
@@ -8,6 +8,8 @@ import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFl
 import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
+
 public class UndergroundFluidChunkRenderStep implements RenderStep {
     private final UndergroundFluidChunkLocation undergroundFluidChunkLocation;
 
@@ -23,7 +25,7 @@ public class UndergroundFluidChunkRenderStep implements RenderStep {
     }
 
     @Override
-    public void draw(GuiScreen gui, double cameraX, double cameraZ, double scale) {
+    public void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale) {
         if (undergroundFluidChunkLocation.getFluidAmount() > 0 && scale >= Utils.journeyMapScaleToLinear(Config.minZoomLevelForUndergroundFluidDetails)) {
             GL11.glPushMatrix();
             GL11.glTranslated(undergroundFluidChunkLocation.getBlockX() - 0.5 - cameraX, undergroundFluidChunkLocation.getBlockZ() - 0.5 - cameraZ, 0);
@@ -43,7 +45,9 @@ public class UndergroundFluidChunkRenderStep implements RenderStep {
             }
 
             GL11.glScaled(1 / scale, 1 / scale, 1);
-            DrawUtils.drawSimpleLabel(gui, getFluidAmountFormatted(), 13, 13, 0xFFFFFFFF, 0xB4000000, false);
+            if (gui != null) {
+                DrawUtils.drawSimpleLabel(gui, getFluidAmountFormatted(), 13, 13, 0xFFFFFFFF, 0xB4000000, false);
+            }
             GL11.glPopMatrix();
         }
     }

--- a/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
+++ b/src/main/java/com/sinthoras/visualprospecting/integration/xaeroworldmap/rendersteps/UndergroundFluidRenderStep.java
@@ -6,6 +6,8 @@ import com.sinthoras.visualprospecting.integration.model.locations.UndergroundFl
 import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.opengl.GL11;
 
+import javax.annotation.Nullable;
+
 public class UndergroundFluidRenderStep implements RenderStep {
 
     private final UndergroundFluidLocation undergroundFluidLocation;
@@ -15,7 +17,7 @@ public class UndergroundFluidRenderStep implements RenderStep {
     }
 
     @Override
-    public void draw(GuiScreen gui, double cameraX, double cameraZ, double scale) {
+    public void draw(@Nullable GuiScreen gui, double cameraX, double cameraZ, double scale) {
         final int maxAmountInField = undergroundFluidLocation.getMaxProduction();
         // < 0.5 scale is when scaling issues show up
         if (maxAmountInField > 0 && scale >= 0.5) {
@@ -31,7 +33,7 @@ public class UndergroundFluidRenderStep implements RenderStep {
             DrawUtils.drawGradientRect(0, 2, 2, lenZ + 2, 0, borderColor, borderColor);
 
             // min scale that journeymap can go to
-            if (scale >= 1) {
+            if (scale >= 1 && gui != null) {
                 GL11.glScaled(1 / scale, 1 / scale, 1);
                 final String label = undergroundFluidLocation.getMinProduction() + "L - " + maxAmountInField + "L  " + undergroundFluidLocation.getFluid().getLocalizedName();
                 DrawUtils.drawSimpleLabel(gui, label, VP.chunkWidth * scale, 0, 0xFFFFFFFF, 0xB4000000, false);

--- a/src/main/java/com/sinthoras/visualprospecting/mixinplugin/Mixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixinplugin/Mixin.java
@@ -35,6 +35,9 @@ public enum Mixin {
 
     GuiMapMixin("xaerosworldmap.GuiMapMixin", Side.CLIENT, XAEROWORLDMAP),
     WaypointsIngameRendererMixin("xaerosminimap.WaypointsIngameRendererMixin", Side.CLIENT, XAEROMINIMAP),
+    MinimapRendererMixin("xaerosminimap.MinimapRendererMixin", Side.CLIENT, XAEROMINIMAP, XAEROWORLDMAP),
+    // used to enable the stencil buffer for on-minimap rendering
+    ForgeHooksClientMixin("minecraft.ForgeHooksClientMixin", Side.CLIENT, XAEROMINIMAP, XAEROWORLDMAP),
 
     ItemEditableBookMixin("minecraft.ItemEditableBookMixin", VANILLA);
 

--- a/src/main/java/com/sinthoras/visualprospecting/mixins/minecraft/ForgeHooksClientMixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixins/minecraft/ForgeHooksClientMixin.java
@@ -1,0 +1,22 @@
+package com.sinthoras.visualprospecting.mixins.minecraft;
+
+import net.minecraftforge.client.ForgeHooksClient;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@SuppressWarnings("UnusedMixin")
+@Mixin(value = ForgeHooksClient.class, remap = false)
+public class ForgeHooksClientMixin {
+
+    // this is only a mixin because it needs to run before the minecraft window is created
+    @Inject(method = "createDisplay",
+            at = @At("HEAD")
+    )
+    private static void enableStencilBuffer(CallbackInfo ci) {
+        // give me my stencil buffer, forge.
+        System.setProperty("forge.forceDisplayStencil", "true");
+    }
+
+}

--- a/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosminimap/MinimapRendererMixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosminimap/MinimapRendererMixin.java
@@ -1,0 +1,104 @@
+package com.sinthoras.visualprospecting.mixins.xaerosminimap;
+
+import com.sinthoras.visualprospecting.integration.model.MapState;
+import com.sinthoras.visualprospecting.integration.model.layers.LayerManager;
+import com.sinthoras.visualprospecting.integration.xaeroworldmap.XaeroWorldMapState;
+import com.sinthoras.visualprospecting.integration.xaeroworldmap.renderers.LayerRenderer;
+import com.sinthoras.visualprospecting.integration.xaeroworldmap.rendersteps.RenderStep;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import xaero.common.XaeroMinimapSession;
+import xaero.common.minimap.MinimapProcessor;
+import xaero.common.minimap.render.MinimapRenderer;
+import xaero.common.minimap.render.MinimapRendererHelper;
+import xaero.common.settings.ModSettings;
+
+import java.util.ArrayList;
+
+@SuppressWarnings("UnusedMixin")
+@Mixin(value = MinimapRenderer.class, remap = false)
+public class MinimapRendererMixin {
+
+    @Shadow protected Minecraft mc;
+
+    @Shadow protected MinimapRendererHelper helper;
+
+    @Inject(method = "renderMinimap",
+            at = @At(value = "INVOKE",
+                    target = "Lxaero/common/minimap/waypoints/render/WaypointsGuiRenderer;render(Lxaero/common/XaeroMinimapSession;Lxaero/common/minimap/render/MinimapRendererHelper;DDIIDDFDZFZ)V"
+            ),
+            locals = LocalCapture.CAPTURE_FAILEXCEPTION
+    )
+    private void injectDraw(XaeroMinimapSession minimapSession, MinimapProcessor minimap, int x, int y, int width, int height, int scale, int size,
+                            float partial, CallbackInfo ci, ModSettings settings, ArrayList<String> underText, int mapSize, int bufferSize,
+                            float minimapScale, float mapScale, float sizeFix, int shape, boolean lockedNorth, double angle, double ps, double pc,
+                            boolean useWorldMap, int lightLevel, boolean cave, boolean circleShape, int scaledX, int scaledY, int minimapFrameSize,
+                            int circleSides, int frameType, boolean renderFrame, int frameTextureX, int halfFrame, int rightCornerStartX, int specH,
+                            boolean safeMode, double playerX, double playerZ) {
+        for (LayerManager layerManager : MapState.instance.layers) {
+            if (layerManager.isLayerActive()) {
+                if (circleShape) {
+                    layerManager.recacheMiniMap((int) mc.thePlayer.posX, (int) mc.thePlayer.posZ, minimapFrameSize);
+                }
+                else {
+                    layerManager.recacheMiniMap((int) mc.thePlayer.posX, (int) mc.thePlayer.posZ, minimapFrameSize, minimapFrameSize);
+                }
+            }
+        }
+
+        GL11.glPushMatrix();
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glRotated(Math.toDegrees(angle) + 90, 0.0, 0.0, 1.0);
+        GL11.glStencilFunc(GL11.GL_EQUAL, 1, 1);
+        for (LayerRenderer renderer : XaeroWorldMapState.instance.renderers) {
+            if (renderer.isLayerActive() && mc.currentScreen != null) {
+                for (RenderStep renderStep : renderer.getRenderSteps()) {
+                    renderStep.draw(mc.currentScreen, playerX, playerZ, scale);
+                }
+            }
+        }
+        GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glPopMatrix();
+    }
+
+    @Inject(method = "renderMinimap",
+            at = @At(value = "INVOKE",
+                    target = "Lorg/lwjgl/opengl/GL11;glScalef(FFF)V",
+                    shift = At.Shift.AFTER
+            ), slice = @Slice(
+                    to = @At(value = "INVOKE",
+                            target = "Lxaero/common/minimap/render/MinimapRendererHelper;drawTexturedElipseInsideRectangle(IFFIIFF)V"
+                    )
+            )
+    )
+    private void injectBeginStencil(XaeroMinimapSession minimapSession, MinimapProcessor minimap, int x, int y, int width, int height, int scale, int size, float partial, CallbackInfo ci) {
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 1);
+        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
+        GL11.glStencilMask(0xFF);
+        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+    }
+
+    @Inject(method = "renderMinimap",
+            at = @At(value = "INVOKE",
+                    target = "Lxaero/common/minimap/MinimapInterface;usingFBO()Z"
+            ), slice = @Slice(
+                    from = @At(value = "INVOKE",
+                            target = "Lxaero/common/minimap/render/MinimapRendererHelper;drawTexturedElipseInsideRectangle(IFFIIFF)V"
+                    )
+            )
+    )
+    private void injectEndStencil(XaeroMinimapSession minimapSession, MinimapProcessor minimap, int x, int y, int width, int height, int scale, int size, float partial, CallbackInfo ci) {
+        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_KEEP);
+        GL11.glStencilMask(0x00);
+        GL11.glDisable(GL11.GL_STENCIL_TEST);
+    }
+}

--- a/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosworldmap/GuiMapMixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosworldmap/GuiMapMixin.java
@@ -29,7 +29,7 @@ import xaero.map.gui.GuiMap;
 import xaero.map.gui.ScreenBase;
 import xaero.map.misc.Misc;
 
-@SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference"})
+@SuppressWarnings({"MixinAnnotationTarget", "UnresolvedMixinReference", "UnusedMixin"})
 @Mixin(value = GuiMap.class, remap = false)
 public abstract class GuiMapMixin extends ScreenBase {
 
@@ -81,9 +81,11 @@ public abstract class GuiMapMixin extends ScreenBase {
                                  int direction, Object var12, boolean mapLoaded, boolean noWorldMapEffect, int mouseXPos, int mouseYPos, double scaleMultiplier,
                                  double oldMousePosZ, double preScale, double fboScale, double secondaryScale, double mousePosX, double mousePosZ, int mouseFromCentreX,
                                  int mouseFromCentreY, double oldMousePosX, int textureLevel, int leveledRegionShift) {
-        // snap the camera to whole pixel values. works around a rendering issue
-        cameraX = Math.round(cameraX * scale) / scale;
-        cameraZ = Math.round(cameraZ * scale) / scale;
+        // snap the camera to whole pixel values. works around a rendering issue but causes another when framerate is uncapped
+        if (mc.gameSettings.limitFramerate >= 255 && !mc.gameSettings.enableVsync) {
+            cameraX = Math.round(cameraX * scale) / scale;
+            cameraZ = Math.round(cameraZ * scale) / scale;
+        }
 
         for (LayerRenderer layer : XaeroWorldMapState.instance.renderers) {
             if (layer instanceof InteractableLayerRenderer) {
@@ -99,13 +101,13 @@ public abstract class GuiMapMixin extends ScreenBase {
                     ordinal = 1,
                     shift = At.Shift.AFTER
             ), slice = @Slice(
-            from = @At(value = "INVOKE",
-                    target = "Lorg/lwjgl/opengl/GL14;glBlendFuncSeparate(IIII)V"
-            ),
-            to = @At(value = "INVOKE",
-                    target = "Lxaero/map/mods/SupportXaeroMinimap;renderWaypoints(Lnet/minecraft/client/gui/GuiScreen;DDIIDDDDLjava/util/regex/Pattern;Ljava/util/regex/Pattern;FLxaero/map/mods/gui/Waypoint;Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/ScaledResolution;)Lxaero/map/mods/gui/Waypoint;"
+                    from = @At(value = "INVOKE",
+                            target = "Lorg/lwjgl/opengl/GL14;glBlendFuncSeparate(IIII)V"
+                    ),
+                    to = @At(value = "INVOKE",
+                            target = "Lxaero/map/mods/SupportXaeroMinimap;renderWaypoints(Lnet/minecraft/client/gui/GuiScreen;DDIIDDDDLjava/util/regex/Pattern;Ljava/util/regex/Pattern;FLxaero/map/mods/gui/Waypoint;Lnet/minecraft/client/Minecraft;Lnet/minecraft/client/gui/ScaledResolution;)Lxaero/map/mods/gui/Waypoint;"
+                    )
             )
-    )
     )
     private void injectDraw(int scaledMouseX, int scaledMouseY, float partialTicks, CallbackInfo ci) {
         for (LayerManager layerManager : MapState.instance.layers) {

--- a/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosworldmap/GuiMapMixin.java
+++ b/src/main/java/com/sinthoras/visualprospecting/mixins/xaerosworldmap/GuiMapMixin.java
@@ -82,7 +82,7 @@ public abstract class GuiMapMixin extends ScreenBase {
                                  double oldMousePosZ, double preScale, double fboScale, double secondaryScale, double mousePosX, double mousePosZ, int mouseFromCentreX,
                                  int mouseFromCentreY, double oldMousePosX, int textureLevel, int leveledRegionShift) {
         // snap the camera to whole pixel values. works around a rendering issue but causes another when framerate is uncapped
-        if (mc.gameSettings.limitFramerate >= 255 && !mc.gameSettings.enableVsync) {
+        if (mc.gameSettings.limitFramerate < 255 || mc.gameSettings.enableVsync) {
             cameraX = Math.round(cameraX * scale) / scale;
             cameraZ = Math.round(cameraZ * scale) / scale;
         }


### PR DESCRIPTION
Adds rendering to Xaero's minimap, similar to Journeymap

Supports minimap expansion (default bound to Z) and zooming 

Ore vein rendering (chunk grid on "grey")
![2022-01-11_15 19 40](https://user-images.githubusercontent.com/66188216/149015419-c9be5ba3-0f0a-423c-9a4a-2bc4c311a3d3.png)
Underground fluid rendering (with minimap expanded)
![2022-01-11_15 19 48](https://user-images.githubusercontent.com/66188216/149015427-2911e863-d5b1-4c96-aa62-67951d08383e.png)
Node rendering (with minimap zoomed in)
![2022-01-11_15 20 11](https://user-images.githubusercontent.com/66188216/149015434-0e66469f-5b17-4714-93f9-4f3fa92dd2b7.png)

Text does not render in the minimap, due to requiring significant code changes to pass through the rotation angle and fully remove the dependency on a `GuiScreen` from `drawSimpleLabel`

Scaling appears to be about half of that of Journeymap

I am enabling the GL stencil buffer for clipping the overlays to the minimap frame, since it causes less issues than using the depth buffer in the same way and does not require drawing a mask texture like Journeymap does for its impl of depth buffer-based clipping

Also fixes a minor issue I found where having an uncapped framerate would cause the world map to jump around due to the rendering workaround I implemented for the world map

(side note: ore vein marker rendering seems to cause serious flickering on fancy leaves. happens with both minimaps' rendering)