### PR TITLE
Fixed not being able to build due to missing artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.5'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
     }
 }
 


### PR DESCRIPTION
Moved ForgeGradle to v1.2.7 as v1.2.5 artifacts don't appear to be available anymore.